### PR TITLE
Add AI video-to-blog MicroSaaS plan and summarizer MVP

### DIFF
--- a/docs/product_plan.md
+++ b/docs/product_plan.md
@@ -1,0 +1,46 @@
+# AI Video-to-Blog MicroSaaS Plan
+
+## Market Research and Opportunity
+- **Problem**: Video creators struggle to repurpose long-form video content into written formats like blogs, newsletters, and social posts.
+- **Gap**: Existing tools focus on editing video clips, but few offer automated high-quality text repurposing tailored for SEO and newsletters.
+- **Target Users**: YouTube creators, course makers, agencies managing video content, and marketing teams needing written collateral from video.
+- **Differentiators**:
+  - Automatic transcription ingestion (from YouTube or uploaded files).
+  - AI summarization tuned for long-form educational or marketing videos.
+  - Output as blog posts, email newsletters, and social media snippets.
+
+## Monetization Plan
+- **Subscription Model** with free trial (10 minutes of video processing).
+- **Tier 1 – Creator ($29/mo)**: Up to 60 minutes of video per month, basic blog and social post export.
+- **Tier 2 – Pro ($79/mo)**: 300 minutes, newsletter templates, SEO keyword suggestions.
+- **Tier 3 – Agency ($199/mo)**: 1200 minutes, team accounts, bulk processing API.
+- **Upsells**: Pay-as-you-go minutes, custom templates, managed repurposing services.
+- **Goal**: Acquire ~140 Pro subscribers and ~40 Agency subscribers to reach ~$1M ARR.
+
+## Product Requirements
+### Core Features
+1. Upload or link a video to fetch transcripts automatically.
+2. Generate blog post drafts, newsletter summary, and social posts.
+3. Dashboard to manage processed videos and exports.
+4. Usage tracking by minutes of video processed.
+
+### User Stories
+- As a creator, I can paste a YouTube link and receive a blog post outline.
+- As a marketer, I can download a newsletter draft in Markdown.
+- As an agency manager, I can invite team members and track minute usage per client.
+
+### Success Metrics
+- Time saved vs manual writing (target 5x faster).
+- Conversion from free trial to paid plan (>20%).
+- Monthly churn <5%.
+
+### Technical Notes
+- Backend: Python or Node API handling transcription fetch and AI summarization.
+- Frontend: React dashboard for uploads and exports.
+- Integrations: YouTube Data API, email marketing export (e.g., Mailchimp format).
+
+## Next Steps
+1. Build MVP with transcript upload and blog post generation.
+2. Launch beta to 10 creators and gather feedback.
+3. Iterate on templates and add newsletter/social exports.
+4. Scale marketing via partnerships with creator communities.

--- a/mvp/summarizer.py
+++ b/mvp/summarizer.py
@@ -1,0 +1,21 @@
+"""Simple transcript summarization utility."""
+from __future__ import annotations
+
+def summarize_transcript(transcript: str, max_sentences: int = 2) -> str:
+    """Return the first ``max_sentences`` sentences of ``transcript``.
+
+    This acts as a placeholder for an AI-powered summarizer.
+    """
+    sentences = [s.strip() for s in transcript.split('.') if s.strip()]
+    summary = '. '.join(sentences[:max_sentences])
+    if summary and not summary.endswith('.'):
+        summary += '.'
+    return summary
+
+if __name__ == "__main__":
+    sample = (
+        "Video content can be long and dense. "
+        "Creators often need a quick overview. "
+        "This utility extracts a simple summary."
+    )
+    print(summarize_transcript(sample))

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,11 @@
+from mvp.summarizer import summarize_transcript
+
+def test_summary_shorter_than_input():
+    text = (
+        "Sentence one. "
+        "Sentence two. "
+        "Sentence three."
+    )
+    summary = summarize_transcript(text, max_sentences=2)
+    assert len(summary) < len(text)
+    assert summary.count('.') == 2


### PR DESCRIPTION
## Summary
- Document market research, monetization strategy, and product requirements for an AI video-to-blog MicroSaaS
- Add placeholder summarization module representing MVP logic
- Include unit test demonstrating summarizer behavior

## Testing
- `python -m pytest tests/test_summarizer.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689e2482695883269ada6278c1a06d79

## Summary by Sourcery

Add AI video-to-blog MicroSaaS plan documentation alongside a placeholder summarizer module and its corresponding unit test

New Features:
- Introduce placeholder summarization module for transcript summarization as an MVP

Documentation:
- Add product plan document detailing market research, monetization strategy, and product requirements for an AI video-to-blog MicroSaaS

Tests:
- Add unit test validating the summarize_transcript function behavior