### PR TITLE
Add basic competitor tracking server with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "andthestik",
+  "version": "1.0.0",
+  "description": "Simple Node server for competitor tracking",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,43 @@
+const http = require('http');
+
+let competitors = [];
+
+function handler(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (req.method === 'POST' && url.pathname === '/competitors') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { name } = JSON.parse(body);
+        if (!name) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          return res.end(JSON.stringify({ error: 'name required' }));
+        }
+        competitors.push({ name });
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid json' }));
+      }
+    });
+  } else if (req.method === 'GET' && url.pathname === '/insights') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: `Tracking ${competitors.length} competitors` }));
+  } else {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  }
+}
+
+const server = http.createServer(handler);
+
+module.exports = server;
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  server.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const server = require('../server');
+
+test('adds competitor and returns insight', async (t) => {
+  await new Promise(resolve => server.listen(0, resolve));
+  const { port } = server.address();
+  const base = `http://localhost:${port}`;
+
+  const addRes = await fetch(`${base}/competitors`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'example.com' })
+  });
+  assert.strictEqual(addRes.status, 201);
+
+  const insightRes = await fetch(`${base}/insights`);
+  assert.strictEqual(insightRes.status, 200);
+  const data = await insightRes.json();
+  assert.match(data.message, /1/);
+
+  server.close();
+});


### PR DESCRIPTION
## Summary
- scaffold minimal HTTP server for competitor tracking with endpoints to add competitors and view insights
- add Node test verifying competitor addition and insight retrieval

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e2482695883269ada6278c1a06d79

## Summary by Sourcery

Implement a minimal competitor tracking HTTP server with POST /competitors and GET /insights endpoints, initialize project config, and add an integration test for competitor addition and insight retrieval.

New Features:
- Introduce a basic HTTP server with a POST /competitors endpoint to register competitors
- Add a GET /insights endpoint to report the total number of tracked competitors

Build:
- Initialize package.json with start and test scripts and set project to CommonJS

Tests:
- Add a node:test-based integration test for adding a competitor and retrieving insights